### PR TITLE
Corrected dependencies in gemspec

### DIFF
--- a/htmltoword.gemspec
+++ b/htmltoword.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rubyzip"
-  spec.add_development_dependency "nokogiri"
+  spec.add_dependency "actionpack"
+  spec.add_dependency "nokogiri"
+  spec.add_dependency "rubyzip"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
nokogiri and rubyzip are runtime dependencies, not development dependencies

added action pack as dependency since action_controller and action_view is also used in the code
