### PR TITLE
User glob in gemspec instead of forking with shell command

### DIFF
--- a/htmltoword.gemspec
+++ b/htmltoword.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/nickfrandsen/htmltoword"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = Dir.glob("{lib}/**/*.rb") + Dir.glob("{templates,xslt}/*") + %w{ README.md Rakefile }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This is the preferred way of specifying the files and should be significantly faster as it does not start a new shell env.
